### PR TITLE
Change 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+PLATFORM/build/
+PLATFORM/target/
+THIRDPARTY/GooglePerfTools/v2.0.0/build/
+THIRDPARTY/GooglePerfTools/v2.0.0/target/
+THIRDPARTY/TinyXML/v1.0.9/CMakeLists.txt
+THIRDPARTY/TinyXML/v1.0.9/build/
+THIRDPARTY/TinyXML/v1.0.9/target/
+THIRDPARTY/jemalloc/v3.6.0/build/
+THIRDPARTY/jemalloc/v3.6.0/target/


### PR DESCRIPTION
Using g++ 6.3 that comes with Ubuntu 17.04  the following compilation error is generated.

```
     [exec] In file included from /home/deepgrant/Development/GIT/deep_platform/PLATFORM/src/test/native/cxx/util/concurrent/TestReentrantReadWriteLock.cxx:38:0,
     [exec]                  from /home/deepgrant/Development/GIT/deep_platform/PLATFORM/src/test/native/cxx/util/concurrent/TestUserSpaceReadWriteLock.cxx:29:
     [exec] /home/deepgrant/Development/GIT/deep_platform/PLATFORM/src/main/native/cxx/util/concurrent/locks/UserSpaceReadWriteLock.h: In instantiation of 'static T cxx::util::concurrent::locks::UserSpaceReadWriteLock::get(T*) [with T = bool]':
     [exec] /home/deepgrant/Development/GIT/deep_platform/PLATFORM/src/main/native/cxx/util/concurrent/locks/UserSpaceReadWriteLock.h:97:67:   required from here
     [exec] /home/deepgrant/Development/GIT/deep_platform/PLATFORM/src/main/native/cxx/util/concurrent/locks/UserSpaceReadWriteLock.h:65:30: error: operand type 'bool*' is incompatible with argument 1 of '__sync_fetch_and_or'
     [exec]     return __sync_fetch_and_or(v, 0);
     [exec]            ~~~~~~~~~~~~~~~~~~~^~~~~~
     [exec] make[2]: *** [CMakeFiles/UserSpaceReadWriteLockTest.dir/src/test/native/cxx/util/concurrent/TestUserSpaceReadWriteLock.cxx.o] Error 1
     [exec] make[1]: *** [CMakeFiles/UserSpaceReadWriteLockTest.dir/all] Error 2
     [exec] make: *** [all] Error 2
```

According to the gcc documentation @ https://gcc.gnu.org/gcc-6/porting_to.html :
```
Cannot convert 'bool' to 'T*'

The current C++ standard only allows integer literals to be used as null pointer constants, so other constants such as false and (1 - 1) cannot be used where a null pointer is desired. Code that fails to compile with this error should be changed to use nullptr, or 0, or NULL.
```

Therefore changing the `boolean` members in the `UserSpaceReadWriteLock.h` to `uinttype` fixed this compilation issue and allowed the tests to run and complete 100% with out further issues.
